### PR TITLE
Conditionally require environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ Then, open [the Twilio Console][twilio-console] in your browser of choice, and c
 
 Then, set those values as the values of `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER`, respectively, in _.env_.
 
+### Configuring the application
+
+Once the project has been bootstrapped, if you want to use the Twilio Rest Client registered with the container, uncomment the first element of the array passed to initialise the `RequiredEnvironmentVariables` object, which is passed to `$dotenv->required()` in _public/index.php_.
+
+For example:
+
+```php
+$dotenv->required(
+    new RequiredEnvironmentVariables([
+        App\Config\RequiredEnvironmentVariables\Spec\TwilioRestClient::class,
+        // App\Config\RequiredEnvironmentVariables\Spec\TwilioPhoneNumber::class,
+    ])->getEnvVars(),
+)->notEmpty();
+```
+
 ## Contributing
 
 If you want to contribute to the project, whether you have found issues with it or just want to improve it, here's how:

--- a/public/index.php
+++ b/public/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Application;
 use DI\Container;
+use App\Config\RequiredEnvironmentVariables;
 use Dotenv\Dotenv;
 use Slim\Factory\AppFactory;
 use Twilio\Rest\Client;
@@ -16,16 +17,12 @@ require __DIR__ . '/../vendor/autoload.php';
 $dotenv = Dotenv::createImmutable(__DIR__ . '/../');
 $dotenv->load();
 
-/**
- * The following three environment variables are are required for using the Twilio Client, and
- * sending notifications (SMS, MMS, and WhatsApp messages). So, we now ensure that they're
- * available and not empty.
- */
-$dotenv->required([
-    'TWILIO_ACCOUNT_SID',
-    'TWILIO_AUTH_TOKEN',
-    'TWILIO_PHONE_NUMBER',
-])->notEmpty();
+$dotenv->required(
+    new RequiredEnvironmentVariables([
+        // App\Config\RequiredEnvironmentVariables\Spec\TwilioRestClient::class,
+        // App\Config\RequiredEnvironmentVariables\Spec\TwilioPhoneNumber::class,
+    ])->getEnvVars(),
+)->notEmpty();
 
 /**
  * We next set up the application's DI container, which uses PHP-DI.

--- a/src/Config/RequiredEnvironmentVariables.php
+++ b/src/Config/RequiredEnvironmentVariables.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config;
+
+use App\Config\RequiredEnvironmentVariables\Spec\SpecInterface;
+use ArrayObject;
+
+use function array_merge;
+
+final class RequiredEnvironmentVariables
+{
+    private ArrayObject $environmentVariables;
+
+    /**
+     * @param array<int,SpecInterface> $envVarSpecs
+     */
+    public function __construct(array $envVarSpecs = [])
+    {
+        $temp = [];
+        foreach ($envVarSpecs as $spec) {
+            $temp = array_merge($temp, new $spec()->envVars);
+        }
+        $this->environmentVariables = new ArrayObject($temp);
+    }
+
+    /**
+     * @return array<int,string> The list of required environment variables
+     */
+    public function getEnvVars(): array
+    {
+        return $this->environmentVariables->getArrayCopy();
+    }
+}

--- a/src/Config/RequiredEnvironmentVariables/Spec/SpecInterface.php
+++ b/src/Config/RequiredEnvironmentVariables/Spec/SpecInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config\RequiredEnvironmentVariables\Spec;
+
+interface SpecInterface
+{
+    /**
+     * @property array<int,string> The list of environment variables which this spec requires
+     */
+    public array $envVars { get; }
+}

--- a/src/Config/RequiredEnvironmentVariables/Spec/TwilioPhoneNumber.php
+++ b/src/Config/RequiredEnvironmentVariables/Spec/TwilioPhoneNumber.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config\RequiredEnvironmentVariables\Spec;
+
+/**
+ * Defines the required environment variables for the Twilio Rest Client
+ */
+class TwilioPhoneNumber implements SpecInterface
+{
+    public array $envVars = [
+        'TWILIO_PHONE_NUMBER',
+    ];
+}

--- a/src/Config/RequiredEnvironmentVariables/Spec/TwilioRestClient.php
+++ b/src/Config/RequiredEnvironmentVariables/Spec/TwilioRestClient.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config\RequiredEnvironmentVariables\Spec;
+
+/**
+ * Defines the required environment variables for the Twilio Rest Client
+ *
+ * @see https://github.com/twilio/twilio-php/blob/main/src/Twilio/Base/BaseClient.php#L20-L21
+ */
+class TwilioRestClient implements SpecInterface
+{
+    public array $envVars = [
+        'TWILIO_ACCOUNT_SID',
+        'TWILIO_AUTH_TOKEN',
+    ];
+}

--- a/test/Config/RequiredEnvironmentVariablesTest.php
+++ b/test/Config/RequiredEnvironmentVariablesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest;
+
+use App\Config\RequiredEnvironmentVariables;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+
+/**
+ * This class tests the RequiredEnvironmentVariables class to ensure that it
+ * only returns a list of the required environment variables.
+ */
+final class RequiredEnvironmentVariablesTest extends TestCase
+{
+    /**
+     * @param array<int,EnvironmentVariableInterface> $requiredEnvironmentVariable
+     */
+    #[TestWith(
+        [
+            [
+                RequiredEnvironmentVariables\Spec\TwilioRestClient::class,
+            ],
+            [
+                'TWILIO_ACCOUNT_SID',
+                'TWILIO_AUTH_TOKEN',
+            ],
+        ],
+        'Load only the environment variables required for a Twilio Rest Client',
+    )]
+    #[TestWith(
+        [
+            [
+                RequiredEnvironmentVariables\Spec\TwilioRestClient::class,
+                RequiredEnvironmentVariables\Spec\TwilioPhoneNumber::class,
+            ],
+            [
+                'TWILIO_ACCOUNT_SID',
+                'TWILIO_AUTH_TOKEN',
+                'TWILIO_PHONE_NUMBER',
+            ],
+        ],
+        'Load only the environment variables required for a Twilio Rest Client, and a Twilio phone number',
+    )]
+    public function testOnlyRequiresTheRequiredEnvironmentVariables(
+        array $requiredEnvironmentVariables,
+        array $expectedEnvironmentVariables,
+    ): void {
+        $requiredEnvVars = new RequiredEnvironmentVariables($requiredEnvironmentVariables);
+        $this->assertCount(count($expectedEnvironmentVariables), $requiredEnvVars->getEnvVars());
+        $this->assertEquals($expectedEnvironmentVariables, $requiredEnvVars->getEnvVars());
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

For the longest time, I've been looking at how the environment variables are set and have been wondering if there was a better way. Is this way that, in its entirety? No. But, I hope that it goes a ways along the way to that.

Specifically, what I mean is that this change introduces a way of programmatically building up the list of required environment variables based on what I'm calling "Spec" classes. Then, it refactors _public/index.php_ to use that new approach, providing commented out examples of using spec classes, to help the developer first get started.

I couldn't think of a better name. They each define a set of environment variables for a given task, object, or spec. I hope that they might make it easier to know which environment variables are required for a given task.